### PR TITLE
Install Claude Code by default

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
       python3 \
  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
- # Install GitHub CLI
+ # Install GitHub CLI \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
@@ -20,6 +20,9 @@ RUN apt-get update \
 # Install agent-browser + Chromium with system deps
 RUN npm install -g agent-browser \
  && npx playwright install-deps chromium
+
+# Install Claude Code by default when available
+RUN npm install -g @anthropic-ai/claude-code || true
 
 COPY package.json index.js /app/
 RUN cd /app && npm install --production

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -104,3 +104,7 @@ Add as an MCP server in the orchestra UI:
 | Headers | `{"x-api-key": "<API_KEY>"}` if auth is enabled, otherwise `{}` |
 
 The `exec_command` tool will appear when fetching tools from the configured server.
+
+## Claude Code
+
+Claude Code is installed by default in the sandbox image when available.


### PR DESCRIPTION
Adds Claude Code installation to the ubuntu sandbox image by default and documents it in the README.